### PR TITLE
Forward slashes in the command are not replaced with backslashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ var os = require('os').type();
 exports = module.exports = spawn;
 function spawn(command, args, options) {
   if (os === 'Windows_NT') {
+    command = command.replace(/\//g, '\\');
+    
     if (command === 'rm') {
       command = 'rmdir';
       if (args[0] === '-rf' || args[0] == '-fr') {


### PR DESCRIPTION
Here's a pull request for feature #4
