### PR TITLE
Fix for issue #8

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,11 +45,6 @@ function spawn(command, args, options) {
         }
       });
     }
-
-    args.unshift(command);
-    args.unshift('/c');
-    args.unshift('/d');
-    command = 'cmd';
   }
   return cSpawn(command, args, options);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "win-spawn",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Spawn for node.js but in a way that works regardless of which OS you're using",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
I haven't found anything that this PR breaks _yet_. Environment variables, stdio and current working directory appear to stay in-tact. It's possible that there is something else this could break, but for our use case, we can't use win-spawn at all without the ability to kill processes.

If this can't be merged, I'll just continue to maintain a one-off fork to resolve the issue for our internal stuff.

Thanks again!
